### PR TITLE
autoExit setting to let dashboard close on its own

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ var spider = sandcrawler.spider('MyFancySpider')
 ## Options
 
 * **logger** *?object*: Any options to pass to the `sandcrawler-logger` used by the dashboard internally. Possible options can be found [here](https://github.com/Yomguithereal/sandcrawler-logger#options).
+* **autoExit** *?bool*: Will wait for Ctrl+c after crawl is finished if falsey or unset, will exit with errorcode 1 otherwise.
 
 *Example*
 

--- a/src/listeners.js
+++ b/src/listeners.js
@@ -125,8 +125,12 @@ module.exports = function(spider, ui, opts) {
   spider.once('spider:teardown', function() {
     clearInterval(renderInterval);
     setTimeout(function() {
-      spider.logger.info('Press Ctrl-c to exit...');
-      render();
+      if (opts.autoExit) {
+        process.exit(1);
+      } else {
+        spider.logger.info('Press Ctrl-c to exit...');
+        render();
+      }
     }, 10);
   });
 


### PR DESCRIPTION
(useful for handling autorestarts after phantom crashes)
